### PR TITLE
iOSサンプルプロジェクトのiOS10対応

### DIFF
--- a/iOS/cocos2d-x/projects/LobiSDKSample/proj.ios/Info.plist
+++ b/iOS/cocos2d-x/projects/LobiSDKSample/proj.ios/Info.plist
@@ -85,5 +85,13 @@
             </dict>
         </dict>
     </dict>
+    
+    <key>NSMicrophoneUsageDescription</key>
+    <string>実況の音声を録音するため、マイクを利用します。</string>
+    <key>NSCameraUsageDescription</key>
+    <string>撮影又は実況用ワイプのため、カメラを利用します。</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>画像投稿又はプロフィールの画像設定に使用するため、写真を利用します。</string>
+    
 </dict>
 </plist>

--- a/iOS/cocos2d/LobiSDKSample/LobiSDKSample/Resources/Info.plist
+++ b/iOS/cocos2d/LobiSDKSample/LobiSDKSample/Resources/Info.plist
@@ -89,13 +89,5 @@
             </dict>
         </dict>
     </dict>
-    
-    <key>NSMicrophoneUsageDescription</key>
-    <string>実況の音声を録音するため、マイクを利用します。</string>
-    <key>NSCameraUsageDescription</key>
-    <string>撮影又は実況用ワイプのため、カメラを利用します。</string>
-    <key>NSPhotoLibraryUsageDescription</key>
-    <string>画像投稿又はプロフィールの画像設定に使用するため、写真を利用します。</string>
-    
 </dict>
 </plist>

--- a/iOS/cocos2d/LobiSDKSample/LobiSDKSample/Resources/Info.plist
+++ b/iOS/cocos2d/LobiSDKSample/LobiSDKSample/Resources/Info.plist
@@ -89,5 +89,13 @@
             </dict>
         </dict>
     </dict>
+    
+    <key>NSMicrophoneUsageDescription</key>
+    <string>実況の音声を録音するため、マイクを利用します。</string>
+    <key>NSCameraUsageDescription</key>
+    <string>撮影又は実況用ワイプのため、カメラを利用します。</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>画像投稿又はプロフィールの画像設定に使用するため、写真を利用します。</string>
+    
 </dict>
 </plist>


### PR DESCRIPTION
参考：LobiSDKをiOS10SDKで動作させる方法
https://github.com/kayac/Lobi/wiki/LobiSDK-iOS10

- Xcode7 / 8 ビルドチェック済み。
- iOS9上で実行チェック済み。
- iOS10上で実行チェック済みです。
- 準備中のiOS10向けSDKとの結合テスト済み。
- 既存SDK 6.4.12との結合テスト済み。

参考）
→ 既存SDK + 新規サンプルではRec録画時に警告Log発生しますが、
　 既に認識・対応しているのもです。（準備中の新規SDKでは警告がなくなる）
→ 既にご存知ように、cocos2d / 2d-xサンプルにはチャットSDK結合テストがない状況です。
